### PR TITLE
Add ruby_vsc_dbg

### DIFF
--- a/lua/dap-install/debuggers/ruby_vsc_dbg.lua
+++ b/lua/dap-install/debuggers/ruby_vsc_dbg.lua
@@ -1,0 +1,39 @@
+local M = {}
+
+local dbg_path = require("dap-install.debuggers_list").debuggers["ruby_vsc_dbg"][2]
+
+M.dap_info = {
+    name_adapter = "ruby",
+    name_configuration = "ruby"
+}
+
+M.config = {
+    adapters = {
+        type = "executable",
+        command = "node",
+        args = {dbg_path .. "extension/dist/debugger/main.js"},
+    },
+    configurations = {
+        {
+            type = "ruby",
+            name = "ruby",
+            request = "launch",
+            program = "${file}",
+            args = {"*${args}"}
+        }
+    }
+}
+
+M.installer = {
+    before = "",
+    install = [[
+        wget https://github.com/rubyide/vscode-ruby/releases/download/v0.25.0/ruby-0.25.0.vsix
+        mv ruby-0.25.0.vsix ruby-0.25.0.zip
+        unzip ruby-0.25.0.zip
+        printf "\n\n\n"
+        echo 'Do not forget to add `ruby-debug-ide` gem to your bundle or system!'
+    ]],
+    uninstall = "simple"
+}
+
+return M

--- a/lua/dap-install/debuggers_list.lua
+++ b/lua/dap-install/debuggers_list.lua
@@ -15,6 +15,7 @@ M.debuggers = {
     ["go_delve_dbg"] = {"dap-install.debuggers.go_delve_dbg", opts.installation_path.."go_delve_dbg/"},
     ["ccppr_lldb_dbg"] = {"dap-install.debuggers.ccppr_lldb_dbg", opts.installation_path.."ccppr_lldb_dbg/"},
     ["dart_dbg"] = {"dap-install.debuggers.dart_dbg", opts.installation_path.."dart_dbg/"},
+    ["ruby_vsc_dbg"] = {"dap-install.debuggers.ruby_vsc_dbg", opts.installation_path.."ruby_vsc_dbg/" }
 }
 
 return M


### PR DESCRIPTION
Hi! I created script for installing vscode debugger for ruby https://github.com/rubyide/vscode-ruby

It is mostly based on the go_delve_dbg and ccppr_vsc_dbg from dev branch. Configuration is taken from vimspector. I haven't seen any tests, so I haven't written any, but I've tested it manually and everything seems to be working well.
I saw that there was an empty file for ruby_dbg but, because it isn't the debugger suggested in nvim-dap, I've decided to follow ccppr_vsc_dbg naming pattern.

The `ruby-debug-ide` gem (gems are ruby lib packages) is required for the debugger to run properly, but since the ruby community uses version managers extensively and switches between different ruby versions and even different gem sets, it is difficult to automate its installation. So I'm just displaying reminder information at the end of the debugger installation. 

I didn't add any documentation, because I didn't know what should I put there.

Feel free to modify anything as you like. :) 