### PR TITLE
 [bugfix] solve problem when install python_dbg(when default python is python2 like mac os .python -> python2, python3 -> python3)

### DIFF
--- a/lua/dap-install/debuggers/python_dbg.lua
+++ b/lua/dap-install/debuggers/python_dbg.lua
@@ -38,7 +38,7 @@ M.config = {
 M.installer = {
 	before = "",
 	install = [[
-		python -m venv .
+		python3 -m venv .
 		bin/python -m pip install debugpy
 	]],
 	uninstall = "simple"


### PR DESCRIPTION
 [bugfix] solve problem when install python_dbg(when default python is python2 like mac os .python -> python2, python3 -> python3)

#8 