### PR TITLE
Fix: don't use sudo npm; also use local gulp

### DIFF
--- a/lua/dap-install/debuggers/jsnode_dbg.lua
+++ b/lua/dap-install/debuggers/jsnode_dbg.lua
@@ -32,7 +32,7 @@ M.installer = {
     install = [[
 		git clone https://github.com/microsoft/vscode-node-debug2.git && cd vscode-node-debug2
 		npm install
-		gulp build
+		npm run build
 	]],
     uninstall = [[
 		cd vscode-node-debug2 && npm uninstall .

--- a/lua/dap-install/debuggers/jsnode_dbg.lua
+++ b/lua/dap-install/debuggers/jsnode_dbg.lua
@@ -31,13 +31,13 @@ M.installer = {
     before = "",
     install = [[
 		git clone https://github.com/microsoft/vscode-node-debug2.git && cd vscode-node-debug2
-		sudo npm install
+		npm install
 		gulp build
 	]],
     uninstall = [[
-		cd vscode-node-debug2 && sudo npm uninstall .
+		cd vscode-node-debug2 && npm uninstall .
 		cd ../..
-		sudo rm -rf jsnode_dbg
+		rm -rf jsnode_dbg
 	]]
 }
 


### PR DESCRIPTION
Remove "sudo" npm commands -- because it's not necessary and has security implications. Npm install runs arbitrary installation scripts, which enables arbitrary code execution as root. Additionally, "npm install" will install into a local node_modules directory,  which the user should have write access to.

Also use the locally installed gulp, instead of the globally installed gulp. This is safer because it respects the correct version supplied by the maintainer.