### PR TITLE
change go_delve_dbg

### DIFF
--- a/lua/dap-install/debuggers/go_delve_dbg.lua
+++ b/lua/dap-install/debuggers/go_delve_dbg.lua
@@ -10,27 +10,37 @@ M.dap_info = {
 
 M.config = {
     adapters = function(callback, config)
+        local stdout = vim.loop.new_pipe(false)
         local handle
         local pid_or_err
         local port = 38697
-        handle, pid_or_err =
-            vim.loop.spawn(
-            "dlv",
-            {
-                args = {"dap", "-l", "127.0.0.1:" .. port},
-                detached = true
-            },
-            function(code)
-                handle:close()
-                print("Delve exited with exit code: " .. code)
-            end
-        )
+        local opts = {
+          stdio = {nil, stdout},
+          args = {"dap", "-l", "127.0.0.1:" .. port},
+          detached = true
+        }
+        handle, pid_or_err = vim.loop.spawn("dlv", opts, function(code)
+          stdout:close()
+          handle:close()
+          if code ~= 0 then
+            print('dlv exited with code', code)
+          end
+        end)
+        assert(handle, 'Error running dlv: ' .. tostring(pid_or_err))
+        stdout:read_start(function(err, chunk)
+          assert(not err, err)
+          if chunk then
+            vim.schedule(function()
+              require('dap.repl').append(chunk)
+            end)
+          end
+        end)
+        -- Wait for delve to start
         vim.defer_fn(
-            function()
-                callback({type = "server", host = "127.0.0.1", port = port})
-            end,
-            100
-        )
+          function()
+            callback({type = "server", host = "127.0.0.1", port = port})
+          end,
+          100)
     end,
     configurations = {
         {
@@ -38,7 +48,28 @@ M.config = {
             name = "Debug",
             request = "launch",
             program = "${file}"
-        }
+        },
+        {
+          type = "go",
+          name = "Debug (go.mode)",
+          request = "launch",
+          program = "./${relativeFileDirname}"
+        },
+        {
+          type = "go",
+          name = "Debug test", -- configuration for debugging test files
+          request = "launch",
+          mode = "test",
+          program = "${file}"
+        },
+        -- works with go.mod packages and sub packages 
+        {
+          type = "go",
+          name = "Debug test (go.mod)",
+          request = "launch",
+          mode = "test",
+          program = "./${relativeFileDirname}"
+        } 
     }
 }
 

--- a/lua/dap-install/debuggers/go_delve_dbg.lua
+++ b/lua/dap-install/debuggers/go_delve_dbg.lua
@@ -45,30 +45,37 @@ M.config = {
     configurations = {
         {
             type = "go",
-            name = "Debug",
+            name = "Attach",
+            request = "attach",
+            processId = require('dap.utils').pick_process,
+            program = "${workspaceFolder}"
+        },
+        {
+            type = "go",
+            name = "Debug curr file",
             request = "launch",
             program = "${file}"
         },
         {
-          type = "go",
-          name = "Debug (go.mode)",
-          request = "launch",
-          program = "./${relativeFileDirname}"
+            type = "go",
+            name = "Debug",
+            request = "launch",
+            program = "${workspaceFolder}"
         },
         {
-          type = "go",
-          name = "Debug test", -- configuration for debugging test files
-          request = "launch",
-          mode = "test",
-          program = "${file}"
+            type = "go",
+            name = "Debug curr test", -- configuration for debugging test files
+            request = "launch",
+            mode = "test",
+            program = "${file}"
         },
         -- works with go.mod packages and sub packages 
         {
-          type = "go",
-          name = "Debug test (go.mod)",
-          request = "launch",
-          mode = "test",
-          program = "./${relativeFileDirname}"
+            type = "go",
+            name = "Debug test",
+            request = "launch",
+            mode = "test",
+            program = "${workspaceFolder}"
         } 
     }
 }


### PR DESCRIPTION
Add `dap. repl` out.
Add `go.mod` supported.

[go-using-delve-directly](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#go-using-delve-directly)