### PR TITLE
feat(python): Add support for auto switching to activated virtualenv

### DIFF
--- a/lua/dap-install/core/debuggers/python.lua
+++ b/lua/dap-install/core/debuggers/python.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local dbg_path = require("dap-install.config.settings").options["installation_path"] .. "python/"
 local fn = vim.fn
+local utils_paths = require("dap-install.utils.paths.init")
 
 M.dap_info = {
 	name_adapter = "python",
@@ -21,7 +22,13 @@ M.config = {
 			name = "Launch file",
 			program = "${file}", -- This configuration will launch the current file if used.
 			pythonPath = function()
-				local cwd = fn.getcwd()
+				local venv_path = os.getenv('VIRTUAL_ENV')
+				if venv_path then
+					if utils_paths.is_windows() then
+						return venv_path .. '\\Scripts\\python.exe'
+					end
+					return venv_path .. '/bin/python'
+				end
 				if fn.executable(dbg_path .. "bin/python") == 1 then
 					return dbg_path .. "bin/python"
 				elseif fn.executable(dbg_path .. "bin/python") == 1 then

--- a/lua/dap-install/utils/paths/init.lua
+++ b/lua/dap-install/utils/paths/init.lua
@@ -4,4 +4,8 @@ function M.assert_dir(dir)
 	return vim.fn.isdirectory("" .. dir .. "")
 end
 
+function M.is_windows()
+	return vim.loop.os_uname().sysname:find("Windows", 1, true) and true
+end
+
 return M


### PR DESCRIPTION
When we have a project using venv, the default python path is not switching to this
venv.
Add support to automatically switching to the current project python path.