### PR TITLE
Fix removing of php/ and jsnode/ folders on uninstall

### DIFF
--- a/lua/dap-install/core/debuggers/jsnode.lua
+++ b/lua/dap-install/core/debuggers/jsnode.lua
@@ -37,7 +37,7 @@ M.installer = {
 	uninstall = [[
 		cd vscode-node-debug2 && npm uninstall .
 		cd ../..
-		rm -rf jsnode_dbg
+		rm -rf jsnode
 	]],
 }
 

--- a/lua/dap-install/core/debuggers/php.lua
+++ b/lua/dap-install/core/debuggers/php.lua
@@ -32,7 +32,7 @@ M.installer = {
 	uninstall = [[
 		cd vscode-php-debug &&  npm uninstall .
 		cd ../..
-		rm -rf php_dbg
+		rm -rf php
 	]],
 }
 


### PR DESCRIPTION
**vscode-php-debug** and **vscode-node-debug2** debuggers are respectively cloned to the `php/` and `jsnode/` folders, but the uninstall statements tries to remove `php_dbg/` and `jsnode_dbg/` folders. This PR fixes that.