### PR TITLE
netcoredbg latest github url broken

### DIFF
--- a/lua/dap-install/core/debuggers/dnetcs.lua
+++ b/lua/dap-install/core/debuggers/dnetcs.lua
@@ -33,7 +33,7 @@ M.config = {
 M.installer = {
 	before = "",
 	install = [[
-		os=$(uname); if [ "$os" = "Linux" ]; then printf "Detected OS: Linux\n"; wget https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-linux-amd64.tar.gz; elif [ "$os" = "Darwin" ]; then printf "Detected OS: Mac\n"; wget https://github.com/Samsung/netcoredbg/releases/download/1.2.0-786/netcoredbg-osx.tar.gz; fi; tar -xvzf netcoredbg-*
+		os=$(uname); if [ "$os" = "Linux" ]; then printf "Detected OS: Linux\n"; wget https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-linux-amd64_fixed.tar.gz; elif [ "$os" = "Darwin" ]; then printf "Detected OS: Mac\n"; wget https://github.com/Samsung/netcoredbg/releases/download/1.2.0-786/netcoredbg-osx.tar.gz; fi; tar -xvzf netcoredbg-*
 	]],
 	uninstall = "simple",
 }


### PR DESCRIPTION
The *nix url for netcoredbg is broken because they didn't follow their usual naming scheme for [1.2.0-825](https://github.com/Samsung/netcoredbg/releases/tag/1.2.0-825).

I pointed  it to the new file name in 1.2.0-825

We could use [1.2.0-786](https://github.com/Samsung/netcoredbg/releases/tag/1.2.0-786) , but then it's a version behind and you have to keep up w/ changes every time they release. We could look at scripting the determination of what to download for latest but that doesn't seem ideal.

Whatever direction is up to you @Pocco81, I will adjust my PR accordingly.


