### PR TITLE
Addition of Unity3D debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,13 +302,13 @@ end
 | `chrome`     | JavaScriptReact, TypeScriptReact | vscode-chrome-debug   | `npm`, `git`            | Tested       |
 | `dart`       | Dart                             | dart-code             | `git`, `npx`            | Supported    |
 | `jsnode`     | JavaScript                       | node-debug2           | `npm`, `git`            | Supported    |
+| `unity`      | Unity3D, C#     |                | UnityDebug            | `mono`, `wget`, `unzip` | Supported |
 | `ruby_vsc`   | Ruby                             | netcoredbg            | `git`, `npm`            | Experimental |
 | `ccppr_lldb` | C, C++, Rust                     | lldb-vscode           | N/A                     | Experimental |
 | `markdown`   | Markdown                         | mockdebug             | N/A                     | Experimental |
 | `java`       | Java                             | java-debug            | N/A                     | Unsupported  |
 | `haskell`    | Haskell                          | haskell-debug-adapter | N/A                     | Unsupported  |
 | `scala`      | Scala                            | nvim-metals           | N/A                     | Unsupported  |
-| `unity`      | Unity3D, C#     |                | UnityDebug            | `mono`, `wget`, `unzip` | Experimental |
 
 -   `Tested`: Fully supported
 -   `Supported`: Fully supported, but needs testing.

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ end
 | `java`       | Java                             | java-debug            | N/A                     | Unsupported  |
 | `haskell`    | Haskell                          | haskell-debug-adapter | N/A                     | Unsupported  |
 | `scala`      | Scala                            | nvim-metals           | N/A                     | Unsupported  |
+| `unity`      | Unity3D, C#     |                | UnityDebug            | `mono`, `wget`, `unzip` | Experimental |
 
 -   `Tested`: Fully supported
 -   `Supported`: Fully supported, but needs testing.

--- a/doc/dap-install.txt
+++ b/doc/dap-install.txt
@@ -222,6 +222,7 @@ end
 | `java`       | Java                             | java-debug            | N/A                     | Unsupported  |
 | `haskell`    | Haskell                          | haskell-debug-adapter | N/A                     | Unsupported  |
 | `scala`      | Scala                            | nvim-metals           | N/A                     | Unsupported  |
+| `unity`      | Unity3D, C#     |                | UnityDebug            | `mono`, `unzip`, `wget` | Experimental |
 
 * `Tested` : Fully supported
 * `Supported` : Fully supported, but needs testing.

--- a/doc/dap-install.txt
+++ b/doc/dap-install.txt
@@ -216,13 +216,13 @@ end
 | `chrome`     | JavaScriptReact, TypeScriptReact | vscode-chrome-debug   | `npm`, `git`            | Tested       |
 | `dart`       | Dart                             | dart-code             | `git`, `npx`            | Supported    |
 | `jsnode`     | JavaScript                       | node-debug2           | `npm`, `git`            | Supported    |
+| `unity`      | Unity3D, C#     |                | UnityDebug            | `mono`, `unzip`, `wget` | Supported |
 | `ruby_vsc`   | Ruby                             | netcoredbg            | `git`, `npm`            | Experimental |
 | `ccppr_lldb` | C, C++, Rust                     | lldb-vscode           | N/A                     | Experimental |
 | `markdown`   | Markdown                         | mockdebug             | N/A                     | Experimental |
 | `java`       | Java                             | java-debug            | N/A                     | Unsupported  |
 | `haskell`    | Haskell                          | haskell-debug-adapter | N/A                     | Unsupported  |
 | `scala`      | Scala                            | nvim-metals           | N/A                     | Unsupported  |
-| `unity`      | Unity3D, C#     |                | UnityDebug            | `mono`, `unzip`, `wget` | Experimental |
 
 * `Tested` : Fully supported
 * `Supported` : Fully supported, but needs testing.

--- a/lua/dap-install/core/debuggers/unity.lua
+++ b/lua/dap-install/core/debuggers/unity.lua
@@ -3,7 +3,7 @@ local M = {}
 local dbg_path = require("dap-install.config.settings").options["installation_path"] .. "unity/"
 
 M.details = {
-	dependencies = {}, --{ "wget", "unzip" },
+	dependencies = { "mono", "wget", "unzip" },
 }
 
 M.dap_info = {

--- a/lua/dap-install/core/debuggers/unity.lua
+++ b/lua/dap-install/core/debuggers/unity.lua
@@ -1,0 +1,43 @@
+local M = {}
+
+local dbg_path = require("dap-install.config.settings").options["installation_path"] .. "unity/"
+
+M.details = {
+	dependencies = {}, --{ "wget", "unzip" },
+}
+
+M.dap_info = {
+	name_adapter = "unity",
+	name_configuration = "cs",
+}
+
+M.config = {
+	adapters = {
+		type = "executable",
+		command = "mono",
+		args = { dbg_path .. "extension/bin/UnityDebug.exe" },
+		name = "Unity Editor",
+	},
+	configurations = {
+		{
+			name = "Unity Editor",
+			type = "unity",
+			request = "launch",
+			path = "Library/EditorInstance.json",
+			__exceptionOptions = {},
+		},
+	},
+}
+
+M.installer = {
+	before = "",
+	install = [[
+        wget -O unity-debug.zip https://github.com/Unity-Technologies/vscode-unity-debug/releases/download/Version-3.0.1/unity-debug-3.0.1.vsix
+        unzip unity-debug.zip
+        echo $PWD
+        printf "\n\n\n"
+    ]],
+	uninstall = "simple",
+}
+
+return M

--- a/lua/dap-install/core/debuggers_list.lua
+++ b/lua/dap-install/core/debuggers_list.lua
@@ -14,6 +14,7 @@ M.debuggers = {
 	["dart"] = { "dart" },
 	["ruby_vsc"] = { "ruby" },
 	["chrome"] = { "javascriptreact", "typescriptreact" },
+ 	["unity"] = { "unity" },
 }
 
 return M


### PR DESCRIPTION
Heya, I've got the Unity3D debugger working!

I suppose the only annoying thing is that it may clash with .NET Core / other *.cs files that people may have installed as well.

I am rolling with the `require('dap.ext.vscode').load_launchjs()` using the `launch.json` defined in the offical project [here](https://github.com/Unity-Technologies/vscode-unity-debug/blob/master/.vscode/launch.json)

Let me know if there's anything missing or questions about the contribution, cheers!