### PR TITLE
fix: remove extra character in chrome debug path

### DIFF
--- a/lua/dap-install/core/debuggers/chrome.lua
+++ b/lua/dap-install/core/debuggers/chrome.lua
@@ -18,7 +18,7 @@ M.config = {
 	adapters = {
 		type = "executable",
 		command = "node",
-		args = { dbg_path .. "/vscode-chrome-debug/out/src/chromeDebug.js" },
+		args = { dbg_path .. "vscode-chrome-debug/out/src/chromeDebug.js" },
 	},
 	configurations = {
 		{


### PR DESCRIPTION
I don't know if this is needed but I was configuring my **nvim-dap** and I run this:
`:lua print(vim.inspect(require('dap').adapters))`

```lua
chrome = {
  args = { "/home/pedro/.local/share/nvim/dapinstall/chrome//vscode-chrome-debug/out/src/chromeDebug.js" },
  command = "node",
  type = "executable"
}, 
node2 = {                                  
  args = { "/home/pedro/.local/share/nvim/dapinstall/jsnode/vscode-node-debug2/out/src/nodeDebug.js" },
  command = "node",
  type = "executable"
}
```
Note the double slash in the chrome debug path