### PR TITLE
fix: python debugger recognised as unmet dependency even when it is already installed

### DIFF
--- a/lua/dap-install/utils/sys.lua
+++ b/lua/dap-install/utils/sys.lua
@@ -38,7 +38,7 @@ end
 function M.program_exists(program)
 	if
 		M.return_exe([[if command -v ]] .. program .. [[ &> /dev/null ; then echo "exists" ; fi
-]], false) == "exists"
+]], false):find("exists",1,true) == 1
 	then
 		return true
 	end


### PR DESCRIPTION
return_exe(cmd, raw) returns 
```
exists /usr/bin/python
```
which is not equal to
```
exists
 ```
in the case of the python debugger. So instead of using strict equality a prefix searching could be used.
