### PR TITLE
Update dnetcs.lua

### DIFF
--- a/lua/dap-install/core/debuggers/dnetcs.lua
+++ b/lua/dap-install/core/debuggers/dnetcs.lua
@@ -33,7 +33,7 @@ M.config = {
 M.installer = {
 	before = "",
 	install = [[
-		os=$(uname); if [ "$os" = "Linux" ]; then printf "Detected OS: Linux\n"; wget https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-linux-amd64_fixed.tar.gz; elif [ "$os" = "Darwin" ]; then printf "Detected OS: Mac\n"; wget https://github.com/Samsung/netcoredbg/releases/download/1.2.0-786/netcoredbg-osx.tar.gz; fi; tar -xvzf netcoredbg-*
+		os=$(uname); if [ "$os" = "Linux" ]; then printf "Detected OS: Linux\n"; wget https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-linux-amd64.tar.gz; elif [ "$os" = "Darwin" ]; then printf "Detected OS: Mac\n"; wget https://github.com/Samsung/netcoredbg/releases/download/1.2.0-786/netcoredbg-osx.tar.gz; fi; tar -xvzf netcoredbg-*
 	]],
 	uninstall = "simple",
 }


### PR DESCRIPTION
fix asset url for dnetcs debugger

It happened again, that the asset was renamed, now it looks more clean, I hope it would not change anymore in the future:

![image](https://user-images.githubusercontent.com/7147208/139039845-798caf5a-fe98-406a-a05f-db0e560082df.png)
