### PR TITLE
fix: conditionally include proxy flags

### DIFF
--- a/lua/dap-install/config/settings.lua
+++ b/lua/dap-install/config/settings.lua
@@ -2,7 +2,7 @@ local settings = {}
 
 settings.options = {
 	installation_path = vim.fn.stdpath("data") .. "/dapinstall/",
-    proxy = false
+	proxy = "",
 }
 
 function settings.set_options(opts)

--- a/lua/dap-install/core/debuggers/ccppr_vsc.lua
+++ b/lua/dap-install/core/debuggers/ccppr_vsc.lua
@@ -44,10 +44,10 @@ M.config = {
 	},
 }
 
-M.installer = {
-	before = "",
-	install = string.format([[
-		wget -e https_proxy=%s $(curl -s https://api.github.com/repos/microsoft/vscode-cpptools/releases/latest -x %s| grep browser_ | cut -d\" -f 4 | grep linux.vsix)
+local install_string
+if proxy == nil or proxy == "" then
+	install_string = [[
+		wget $(curl -s https://api.github.com/repos/microsoft/vscode-cpptools/releases/latest | grep browser_ | cut -d\" -f 4 | grep linux.vsix)
 		mv cpptools-linux.vsix cpptools-linux.zip
 		unzip cpptools-linux.zip
 		chmod +x extension/debugAdapters/bin/OpenDebugAD7
@@ -56,7 +56,28 @@ M.installer = {
 		cd gdb-10.2/
 		./configure
 		make
-	]], proxy, proxy),
+	]]
+else
+	install_string = string.format(
+		[[
+      wget -e https_proxy=%s $(curl -s https://api.github.com/repos/microsoft/vscode-cpptools/releases/latest -x %s| grep browser_ | cut -d\" -f 4 | grep linux.vsix)
+      mv cpptools-linux.vsix cpptools-linux.zip
+      unzip cpptools-linux.zip
+      chmod +x extension/debugAdapters/bin/OpenDebugAD7
+      cp extension/cppdbg.ad7Engine.json extension/debugAdapters/bin/nvim-dap.ad7Engine.json
+      wget https://ftp.gnu.org/gnu/gdb/gdb-10.2.tar.xz && tar -xvf gdb-10.2.tar.xz
+      cd gdb-10.2/
+      ./configure
+      make
+    ]],
+		proxy,
+		proxy
+	)
+end
+
+M.installer = {
+	before = "",
+	install = install_string,
 	uninstall = "simple",
 }
 

--- a/lua/dap-install/core/debuggers/python.lua
+++ b/lua/dap-install/core/debuggers/python.lua
@@ -46,12 +46,25 @@ M.config = {
 	},
 }
 
+local install_string
+if proxy == nil or proxy == "" then
+	install_string = [[
+		python3 -m venv .
+		bin/python -m pip install debugpy
+  ]]
+else
+	install_string = string.format(
+		[[
+      python3 -m venv .
+      bin/python -m pip install debugpy --proxy %s
+    ]],
+		proxy
+	)
+end
+
 M.installer = {
 	before = "",
-	install = string.format([[
-		python3 -m venv .
-		bin/python -m pip install debugpy --proxy %s
-	]], proxy),
+	install = install_string,
 	uninstall = "simple",
 }
 


### PR DESCRIPTION
I think #51 may have introduced a bug in the installers for `python` or `ccppr_vsc` -- when `proxy` was not set (or left to the default `false`), `DIInstall python` tried to call:

```bash
python3 -m venv .
bin/python -m pip install debugpy --proxy false
```

causing an error since `--proxy false` is not a valid argument for pip.

I suspect this is also the cause of #58.

This PR fixes that by conditionally adding the proxy flags (i.e., if `proxy` is `""` or `nil`, it won't add any proxy flags to the commands).